### PR TITLE
Add tray icon option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ nativefier \
   https://chat.openai.com/chat \
   --icon ./chatgpt.icns \
   --name 'ChatGPT' \
+  --tray \
   --background-color '#ffffff' \
   --darwin-dark-mode-support true \
   --title-bar-style hiddenInset \


### PR DESCRIPTION
## Summary
- enable tray icon for ChatGPT by adding the `--tray` argument in the build instructions

## Testing
- `grep -n -- '--tray' README.md`

------
https://chatgpt.com/codex/tasks/task_e_684b880137408327ae1d26ba5402d7f4