### PR TITLE
Add build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,21 @@ Clone the repository:
 git clone https://github.com/nezort11/nativefier.git
 ```
 
-Run the command to create a macos app:
+Run the command to create a macOS app:
+
+```
+./build.sh
+```
+
+The script contains the following invocation of `nativefier`:
 
 ```
 nativefier \
   https://chat.openai.com/chat \
-  --icon ./chatgpt.icns \
   --name 'ChatGPT' \
+  --icon ./chatgpt.icns \
   --tray \
+  --tray-icon ./chatgpt.icns \
   --background-color '#ffffff' \
   --darwin-dark-mode-support true \
   --title-bar-style hiddenInset \

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+nativefier \
+  https://chat.openai.com/chat \
+  --name 'ChatGPT' \
+  --icon ./chatgpt.icns \
+  --tray \
+  --tray-icon ./chatgpt.icns \
+  --background-color '#ffffff' \
+  --darwin-dark-mode-support true \
+  --title-bar-style hiddenInset \
+  --inject ./chatgpt.css \
+  --inject ./chatgpt.js \
+  --min-width 320 \
+  --min-height 568 \
+  --browserwindow-options '{ "trafficLightPosition": { "x": 16, "y": 16 } }' \
+  --disable-old-build-warning-yesiknowitisinsecure


### PR DESCRIPTION
## Summary
- add `build.sh` to simplify running nativefier
- update README with instructions to use the build script

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b8f8036708327bfc1132bb2e53021