### PR TITLE
Add simplified nativefier command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,15 @@ nativefier \
   --browserwindow-options '{ "trafficLightPosition": { "x": 16, "y": 16 } }' \
   --disable-old-build-warning-yesiknowitisinsecure
 ```
+
+Alternatively, you can create the application with a simplified command:
+
+```sh
+nativefier \
+  --name "ChatGPT" \
+  --tray \
+  --tray-icon /path/to/chatgpt-icon.png \
+  --single-instance \
+  https://chat.openai.com \
+  ~/Applications
+```


### PR DESCRIPTION
## Summary
- document an easier nativefier command that uses `--tray-icon` and `--single-instance`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b8bbd36f483278474a95578293220